### PR TITLE
[CCTRI-876] Support versioning for Relay Template

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,9 @@
 import os
 
+from version import VERSION
 
-class Config(object):
+
+class Config:
+    VERSION = VERSION
+
     SECRET_KEY = os.environ.get('SECRET_KEY', '')

--- a/version.py
+++ b/version.py
@@ -1,0 +1,2 @@
+# The version of the Relay API Template the current Relay API is based on.
+__version__ = '0.0.0'

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 # The version of the Relay API Template the current Relay API is based on.
-__version__ = '0.0.0'
+VERSION = '0.0.0'


### PR DESCRIPTION
The actual version will be updated to `0.1.0` via the corresponding `release-0.1.0` branch.