### PR TITLE
Rename tile-id to tile_id as per SecureX convention

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -38,7 +38,7 @@ class ActionFormParamsSchema(Schema):
 
 class DashboardTileSchema(Schema):
     tile_id = fields.String(
-        data_key='tile-id',
+        data_key='tile_id',
         validate=validate_string,
         required=True
     )
@@ -51,7 +51,7 @@ class DashboardTileDataSchema(Schema):
         required=True
     )
     tile_id = fields.String(
-        data_key='tile-id',
+        data_key='tile_id',
         validate=validate_string,
         required=True
     )

--- a/tests/unit/api/test_dashboard.py
+++ b/tests/unit/api/test_dashboard.py
@@ -12,35 +12,35 @@ WrongCall = namedtuple('WrongCall', ('endpoint', 'payload', 'message'))
 def wrong_calls():
     yield WrongCall(
         '/tiles/tile',
-        {'tile_id': 'some_value'},
-        "{'tile-id': ['Missing data for required field.'], "
-        "'tile_id': ['Unknown field.']}"
+        {'tile-id': 'some_value'},
+        "{'tile_id': ['Missing data for required field.'], "
+        "'tile-id': ['Unknown field.']}"
     )
     yield WrongCall(
         '/tiles/tile',
-        {'tile-id': ''},
-        "{'tile-id': ['Field may not be blank.']}"
+        {'tile_id': ''},
+        "{'tile_id': ['Field may not be blank.']}"
     )
     yield WrongCall(
         '/tiles/tile-data',
-        {'tile_id': 'some_value', 'period': 'some_period'},
-        "{'tile-id': ['Missing data for required field.'], "
-        "'tile_id': ['Unknown field.']}"
+        {'tile-id': 'some_value', 'period': 'some_period'},
+        "{'tile_id': ['Missing data for required field.'], "
+        "'tile-id': ['Unknown field.']}"
     )
     yield WrongCall(
         '/tiles/tile-data',
-        {'tile-id': '', 'period': 'some_period'},
-        "{'tile-id': ['Field may not be blank.']}"
+        {'tile_id': '', 'period': 'some_period'},
+        "{'tile_id': ['Field may not be blank.']}"
     )
     yield WrongCall(
         '/tiles/tile-data',
-        {'tile-id': 'some_value', 'not_period': 'some_period'},
+        {'tile_id': 'some_value', 'not_period': 'some_period'},
         "{'period': ['Missing data for required field.'], "
         "'not_period': ['Unknown field.']}"
     )
     yield WrongCall(
         '/tiles/tile-data',
-        {'tile-id': 'some_value', 'period': ''},
+        {'tile_id': 'some_value', 'period': ''},
         "{'period': ['Field may not be blank.']}"
     )
 


### PR DESCRIPTION
Examining the built-in SecureX dashboard modules - the tile API endpoint required a value for `tile_id` rather than `tile-id` as specified in the schema.

Not sure what is the correct id name as I can't seem to find any documentation about this?

Fix for #19 